### PR TITLE
 Fix: Resolve naming collision and commit message formatting for git-commit skill

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,8 +1,5 @@
 {
-    "name": "geminicli-gitcommit",
-    "version": "0.2.0",
-    "excludeTools": [],
-    "tools": ["list_directory", "search_file_content", "read_file", "glob", "replace", "run_shell_command", "save_memory"],
-    "model": "flash",
-    "temperature" : 0.0
-  }
+  "name": "geminicli-gitcommit",
+  "version": "0.3.0",
+  "excludeTools": []
+}

--- a/skills/gitcommit/SKILL.md
+++ b/skills/gitcommit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: git-commit
+name: skill-git-commit
 description: Expert Git commit message generation following Conventional Commits. Use when the user wants to commit changes, needs help writing a commit message, or asks to "commit this".
 ---
 

--- a/skills/gitcommit/references/commit-standards.md
+++ b/skills/gitcommit/references/commit-standards.md
@@ -31,6 +31,7 @@
 *   Use **imperative mood** (e.g., "add", "fix", "change").
 *   Lowercase start, no trailing period.
 *   **NO BACKTICKS**: Never use backticks (`) in the subject.
+*   **NO DOUBLE QUOTES**: Never use double quotes (") in the subject. Use single quotes (') instead.
 
 ## Body Formatting
 *   Blank line after subject.
@@ -38,6 +39,7 @@
 *   Use bulleted lists (`-`) for multiple distinct changes.
 *   Wrap at 72 characters.
 *   **NO BACKTICKS**: Never use backticks (`) in the body. Use single quotes (') instead if needed.
+*   **NO DOUBLE QUOTES**: Never use double quotes (") in the body. Use single quotes (') instead to prevent command truncation.
 
 ## Breaking Changes
 *   **Detection:** Look for removal of public API, signature changes, or incompatible config changes.


### PR DESCRIPTION
# Summary

This PR addresses the critical issues reported in #25 regarding the git-commit agent skill. It eliminates the naming collision with the `/git:commit` slash command by renaming the skill and introduces strict formatting rules to prevent commit message truncation caused by improper quote handling in the shell.

Changes Made

 * Renamed the skill from `git-commit` to `skill-git-commit`. This resolves the ambiguity and potential
   execution errors caused by the naming collision with the `/git:commit` slash command.
 * Updated Commit Standards to explicitly prohibit the use of double quotes (") in both the commit
   subject and body.
 * Introduced single-quote enforcement as the standard for quoting or emphasis within commit
   messages. This ensures that generated git commit commands are not prematurely truncated by the
   shell, leading to cleaner and more reliable commit logs.
     
## Related Issues

Closes #25

## Type of Change

Please select the type of change that applies to this PR:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation (changes to documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, build process, etc.)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

## Screenshots/Video

If your changes affect the UI/UX, please provide screenshots or a video recording.
